### PR TITLE
Issue38/reset shape

### DIFF
--- a/src/components/EditSVGPage.tsx
+++ b/src/components/EditSVGPage.tsx
@@ -151,7 +151,7 @@ const EditSVGPage = ({ svgString, setLoading }: Props) => {
         ref={canvasRef}
         id="myCanvas"
       ></canvas>
-      <div className="float-right">
+      <div className="flex justify-between">
         <Button style={{ marginRight: 5 }} onClick={onClearClicked}>
           Reset
         </Button>

--- a/src/components/EditSVGPage.tsx
+++ b/src/components/EditSVGPage.tsx
@@ -152,7 +152,9 @@ const EditSVGPage = ({ svgString, setLoading }: Props) => {
         id="myCanvas"
       ></canvas>
       <div className="float-right">
-        <Button onClick={onClearClicked}>Clear</Button>
+        <Button style={{ marginRight: 5 }} onClick={onClearClicked}>
+          Reset
+        </Button>
         <Button onClick={onSaveClicked}>Save</Button>
       </div>
     </div>

--- a/src/components/EditSVGPage.tsx
+++ b/src/components/EditSVGPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import paper from 'paper';
 import { Button } from '@/components/ui/button';
 import DOMPurify from 'dompurify';
@@ -21,6 +21,7 @@ const EditSVGPage = ({ svgString, setLoading }: Props) => {
     USE_PROFILES: { svg: true },
   });
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [resetCount, setResetCount] = useState<number>(0);
 
   const postSVG = useCallback((svg: string) => {
     //PUT to the /api/pdf/ route
@@ -121,7 +122,7 @@ const EditSVGPage = ({ svgString, setLoading }: Props) => {
         path.position = (path.position as paper.Point).add(event.delta);
       }
     };
-  }, [sanitizedSvg]);
+  }, [sanitizedSvg, resetCount]);
 
   const onSaveClicked = useCallback(() => {
     const svg = paper.project.exportSVG({ asString: true }) as string;
@@ -129,6 +130,10 @@ const EditSVGPage = ({ svgString, setLoading }: Props) => {
 
     postSVG(svg);
   }, [postSVG, setLoading]);
+
+  const onClearClicked = useCallback(() => {
+    setResetCount((reset) => reset + 1);
+  }, [setResetCount]);
 
   return (
     <div>
@@ -147,6 +152,7 @@ const EditSVGPage = ({ svgString, setLoading }: Props) => {
         id="myCanvas"
       ></canvas>
       <div className="float-right">
+        <Button onClick={onClearClicked}>Clear</Button>
         <Button onClick={onSaveClicked}>Save</Button>
       </div>
     </div>


### PR DESCRIPTION
## Description

Resetting shape to original SVG layout after clicking the reset button

Fixes #38  

## How it was implemented

To re-render the useEffect, used a reset counter, where it would increment when the reset button is clicked

## How it was testedlo

After moving the SVG shapes away from the original position, verified they move back to their original positions after clicking the reset button


## Screenshots or video
![Screenshot 2023-11-24 at 8 44 20 PM](https://github.com/Joshua-Pow/Placement/assets/79180910/8e214a97-9deb-4280-899d-bb68745a6acd)
