### PR TITLE
Fix hardcoding of pattern pdf input and support parsing of multiple p…

### DIFF
--- a/api/extraction.py
+++ b/api/extraction.py
@@ -9,69 +9,98 @@ def convert_pdf_to_jpg(filename: str):
 
         Parameters:
             filename (str): path to a pdf file
+
+        Returns:
+            image_paths: list of output image paths
     """
 
     pdf_images = pdf2image.convert_from_path(filename)
 
+    image_paths = []
     for i in range(len(pdf_images)):
-        pdf_images[i].save("./api/pattern_images/pattern_page_" + str(i + 1) + ".jpg")
+        output_path = "./api/pattern_images/pattern_page_" + str(i + 1) + ".jpg"
+        pdf_images[i].save(output_path)
+        image_paths.append(output_path)
+
+    return image_paths
 
 
-def extract_from_image(filename: str):
+def extract_from_image(filename_paths):
     """
     Extracts shape contours from an image and save as SVG paths.
 
         Parameters:
-            filename (str): path to a pdf file
-    """
-    im = cv.imread(filename)
-    assert im is not None, "file could not be read, check with os.path.exists()"
+            filename_paths: paths to jpg images
 
-    # Convert the img to grayscale
-    imgray = cv.cvtColor(im, cv.COLOR_BGR2GRAY)
-
-    # canny edge detector
-    imedged = cv.Canny(imgray, 10, 100)
-
-    # dilation of image to make edges thicker so pixels in a connected curve can be detected as a continous contour
-    kernel = np.ones((5, 5), np.uint8)
-    im_dilated = cv.dilate(imedged, kernel, iterations=1)
-
-    # debug
-    # cv.imshow('im', im_dilated)
-    # cv.waitKey()
-
-    ret, thresh = cv.threshold(im_dilated, 127, 255, 0)
-    contours, hierarchy = cv.findContours(
-        thresh, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE
-    )
-    print("extracted:", len(contours), "contours")
-
-    # draw contours on original image
-    cv.drawContours(im, contours, -1, (0, 255, 0), 3)
-
-    # Show in a window
-    # cv.imshow('Contours', im)
-    # cv.waitKey()
-
-    """ 
-    for c in contours:
-        print(len(c))
+        Returns:
+            output_svg_path: path to SVG file
     """
 
-    height, width = imgray.shape
-    print("height:", height, "width:", width)
+    all_contours = []
+    pages_height = []
+    total_height = 0
+
+    for i in range(len(filename_paths)):
+        filename = filename_paths[i]
+        im = cv.imread(filename)
+        assert im is not None, "file could not be read, check with os.path.exists()"
+
+        # Convert the img to grayscale
+        imgray = cv.cvtColor(im, cv.COLOR_BGR2GRAY)
+
+        # canny edge detector
+        imedged = cv.Canny(imgray, 10, 100)
+
+        # dilation of image to make edges thicker so pixels in a connected curve can be detected as a continous contour
+        kernel = np.ones((5, 5), np.uint8)
+        im_dilated = cv.dilate(imedged, kernel, iterations=1)
+
+        # debug
+        # cv.imshow('im', im_dilated)
+        # cv.waitKey()
+
+        ret, thresh = cv.threshold(im_dilated, 127, 255, 0)
+        contours, hierarchy = cv.findContours(
+            thresh, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE
+        )
+        print("extracted:", len(contours), "contours")
+
+        # draw contours on original image
+        cv.drawContours(im, contours, -1, (0, 255, 0), 3)
+
+        # Show in a window
+        # cv.imshow('Contours', im)
+        # cv.waitKey()
+
+        """ 
+        for c in contours:
+            print(len(c))
+        """
+
+        all_contours.append(contours)
+
+        height, width = imgray.shape
+
+        pages_height.append(height)
+        total_height += height
 
     # save to a svg file
-    with open("./api/simple_shapes.svg", "w+") as f:
+    output_svg_path = "./api/simple_shapes.svg"
+    with open(output_svg_path, "w+") as f:
         f.write(
-            f'<svg viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg">'
+            f'<svg viewBox="0 0 {width} {total_height}" xmlns="http://www.w3.org/2000/svg">'
         )
 
-        for c in contours:
-            f.write('<path d="M')
-            for i in range(len(c)):
-                x, y = c[i][0]
-                f.write(f"{x} {y} ")
-            f.write('Z" fill="none" stroke="yellow" stroke-width="3"/>')
+        for i in range(len(all_contours)):
+            contours = all_contours[i]
+            for c in contours:
+                f.write('<path d="M')
+                for j in range(len(c)):
+                    x, y = c[j][0]
+                    if i != 0:
+                        y += pages_height[i - 1]
+                    f.write(f"{x} {y} ")
+                f.write('Z" fill="none" stroke="yellow" stroke-width="3"/>')
         f.write("</svg>")
+
+    return output_svg_path

--- a/api/extraction.py
+++ b/api/extraction.py
@@ -3,9 +3,9 @@ import numpy as np
 from pdf2image import pdf2image
 
 
-def convert_pdf_to_jpg(filename: str):
+def convert_pdf_to_png(filename: str):
     """
-    Converts a pdf to individual jpg images and save them in the api/pattern_images folder.
+    Converts a pdf to individual png images and save them in the api/pattern_images folder.
 
         Parameters:
             filename (str): path to a pdf file
@@ -18,7 +18,7 @@ def convert_pdf_to_jpg(filename: str):
 
     image_paths = []
     for i in range(len(pdf_images)):
-        output_path = "./api/pattern_images/pattern_page_" + str(i + 1) + ".jpg"
+        output_path = "./api/pattern_images/pattern_page_" + str(i + 1) + ".png"
         pdf_images[i].save(output_path)
         image_paths.append(output_path)
 
@@ -30,7 +30,7 @@ def extract_from_image(filename_paths):
     Extracts shape contours from an image and save as SVG paths.
 
         Parameters:
-            filename_paths: paths to jpg images
+            filename_paths: paths to images
 
         Returns:
             output_svg_path: path to SVG file

--- a/api/index.py
+++ b/api/index.py
@@ -4,7 +4,7 @@ from flask_restx import Api, Resource
 import os
 import json
 from werkzeug.utils import secure_filename
-from api.extraction import convert_pdf_to_jpg, extract_from_image
+from api.extraction import convert_pdf_to_png, extract_from_image
 from api.parse_svg_input_constaints import parse_svg, translate_polygons_to_SVG
 from api.polygon import Polygon
 from api.rectangle_nesting import rectangle_packing
@@ -46,7 +46,7 @@ class Pdf(Resource):
             file.save(savePath)
 
             # TODO: better file path naming
-            image_paths = convert_pdf_to_jpg(savePath)
+            image_paths = convert_pdf_to_png(savePath)
             svg_output_path = extract_from_image(image_paths)
             # Send the processed file as a response
             return send_from_directory("./", "simple_shapes.svg", as_attachment=True)

--- a/api/index.py
+++ b/api/index.py
@@ -45,10 +45,9 @@ class Pdf(Resource):
             savePath = os.path.join(path, secureName)
             file.save(savePath)
 
-            # TODO: convert the uploaded file to jpg and then extract
-            # convert_pdf_to_jpg(savePath)
-            extract_from_image("./api/pattern_images/simple_shapes.jpg")
-
+            # TODO: better file path naming
+            image_paths = convert_pdf_to_jpg(savePath)
+            svg_output_path = extract_from_image(image_paths)
             # Send the processed file as a response
             return send_from_directory("./", "simple_shapes.svg", as_attachment=True)
         else:


### PR DESCRIPTION


## Description

Fix to use the actual pdf file as input, and also support parsing of multiple pattern pages in one file. The result output is still one single SVG file that contains all detected shapes.

Fixes #40

## How it was implemented

First convert the pdf to multiple images and loop through all images to detect shapes.

## How it was tested

An example pdf that has 2 pages are used to test.
[example_pattern.pdf](https://github.com/Joshua-Pow/Placement/files/13465953/example_pattern.pdf)

## Screenshots or video

UI result after the example pdf is uploaded. 
![image](https://github.com/Joshua-Pow/Placement/assets/61958332/a438df00-50b2-4ff2-847b-488f8d3856ab)
