### PR TITLE
Shape mirroring member function in the Polygon class

### DIFF
--- a/api/parse_svg_input_constaints.py
+++ b/api/parse_svg_input_constaints.py
@@ -95,7 +95,8 @@ def translate_polygons_to_SVG(polygons, viewbox_width, viewbox_height, new_filen
 def duplicate_polygon(polygons, pid, quantity):
     """
     Duplicate a particular polygon shape in the polygond data structure to a certain quantity.
-    The caller of this function should ideally already checked the pid to be valid, and quantity is a finite integer>2
+    The caller of this function should ideally already checked the pid to be valid, and quantity is a finite integer>2.
+    When a piece is duplicated, if user wants a even quantity, then half of the pieces are mirrored (ie. left and right pant)
     """
 
     if pid < 0 or pid >= len(polygons):
@@ -103,7 +104,7 @@ def duplicate_polygon(polygons, pid, quantity):
         return
 
     p = polygons[pid]
-    print("polygon to be duplicated: x:{},y:{}", p.x, p.y)
+    mirror = quantity % 2 == 0  # even quantity
 
     for i in range(quantity - 1):
         new = Polygon(
@@ -115,15 +116,19 @@ def duplicate_polygon(polygons, pid, quantity):
             bonding_box_margin=p.bonding_box_margin,
             pid=len(polygons),
         )
+
+        if mirror and (i % 2 == 0):
+            new.mirror_around_centre_y_axis()
+
         polygons.append(new)
 
 
 ## Usage ##
 # polygons = parse_svg("./api/simple_shapes.svg")
-# duplicate_polygon(polygons, 1, 2)  # duplicate the pid=1 shape to have 2 of it
+# duplicate_polygon(polygons, 1, 4)  # duplicate the pid=1 shape to have 2 of it
 
 # container_max_x = 10000
 # container_max_y = 4000
 # rectangle_packing(polygons, container_max_x, container_max_y)
 
-# translate_polygons_to_SVG(polygons, 2000, 2000, "./api/new_placement_dup.svg")
+# translate_polygons_to_SVG(polygons, 2000, 6000, "./api/new_placement_dup.svg")

--- a/api/polygon.py
+++ b/api/polygon.py
@@ -70,3 +70,15 @@ class Polygon(object):
 
     def toJSON(self):
         return json.dumps(self, default=lambda o: o.__dict__)
+
+    def mirror_around_centre_y_axis(self):
+        """
+        Mirror a polygon shape around the centre horizontal y-axis.
+        """
+        centre_y = self.bbox_low_y + self.bbox_h / 2
+
+        for coord in self.contour:
+            if coord[1] > centre_y:
+                coord[1] = centre_y - (coord[1] - centre_y)
+            else:
+                coord[1] = centre_y + (centre_y - coord[1])


### PR DESCRIPTION
Mirror a polygon around its centre y-axis. And use this function in the piece duplication for a piece that requires an even quantity (ie. 2 for a pattern piece for the left and right pant)

## Description

Supports the y-axis mirroring of a shape. This function is used in pattern piece duplication, as well as cut-on-centre-fold pieces.

Fixes #59 

## How it was implemented

Calculate the centre y-axis given the lowest y coordinate and the height of the shape's bounding box. Then calculate the mirrored y coordinate from the centre y-axis.

## How it was tested

Tested locally by calling the function and checking the output contour/y-coordinates. The below screenshot shows that one piece is duplicated to have a quantity of 4 and half of the same piece are mirrored. 

## Screenshots or video

<img width="226" alt="image" src="https://github.com/Joshua-Pow/Placement/assets/61958332/4cfb5b72-8667-4640-8d06-28c9e41a8a8d">

