### PR TITLE
Issue43/centre fold shape manipulation

### DIFF
--- a/api/parse_svg_input_constaints.py
+++ b/api/parse_svg_input_constaints.py
@@ -128,6 +128,7 @@ def duplicate_polygon(
 ## Usage ##
 # polygons = parse_svg("./api/simple_shapes.svg")
 # duplicate_polygon(polygons, 1, 4)  # duplicate the pid=1 shape to have 2 of it
+# polygons[2].centre_fold_manip("bottom")
 
 # container_max_x = 10000
 # container_max_y = 4000

--- a/api/polygon.py
+++ b/api/polygon.py
@@ -209,10 +209,11 @@ class Polygon(object):
 
         # update contour
         self.contour = new_contour
+        num_points = len(self.contour)
         # print(self.contour)
 
         # add the new mirrorred points
-        for i in reversed(range(len(self.contour))):
+        for i in reversed(range(num_points)):
             coord = self.contour[i]
             if fold_line == "bottom":
                 new_y_coord = fold_line_axis - coord[1] + fold_line_axis

--- a/api/polygon.py
+++ b/api/polygon.py
@@ -1,4 +1,50 @@
 import json
+import cv2 as cv
+import numpy as np
+
+
+def test_same_line(prev_coord, curr_coord, is_horizontal, line_axis):
+    """
+    Helper function to test if curr_coord is part of a fold line axis.
+    Args:
+        prev_coord: previous xy coordinate, list of two items
+        curr_coord: current xy coordinate trying to test, list of two items
+        is_horizontal: bool, True if it's a horizontal fold line
+        line_axis: x or y value of the line axis
+    Returns:
+        bool, True if curr_coord is part of the fold line
+    """
+
+    # need to make sure x or y value is within a small range of the line axis
+    tolerance = 5
+
+    if is_horizontal:
+        if curr_coord[1] == line_axis:
+            return True
+        if ((line_axis - tolerance) < prev_coord[1] < (line_axis + tolerance)) and (
+            (line_axis - tolerance) < curr_coord[1] < (line_axis + tolerance)
+        ):
+            dy = abs(prev_coord[1] - curr_coord[1])
+            dx = abs(prev_coord[0] - curr_coord[0])
+
+            # if dy/dx is tiny, assume it's on the same line
+            if (dx != 0) and ((dy / dx) < 0.1):
+                return True
+
+    else:
+        if curr_coord[0] == line_axis:
+            return True
+        if ((line_axis - tolerance) < prev_coord[0] < (line_axis + tolerance)) and (
+            (line_axis - tolerance) < curr_coord[0] < (line_axis + tolerance)
+        ):
+            dy = abs(prev_coord[1] - curr_coord[1])
+            dx = abs(prev_coord[0] - curr_coord[0])
+
+            # if dx/dy is tiny, assume it's on the same line
+            if (dy != 0) and ((dx / dy) < 0.1):
+                return True
+
+    return False
 
 
 class Polygon(object):
@@ -97,32 +143,134 @@ class Polygon(object):
     def centre_fold_manip(self, fold_line):
         """
         Manipulate the centre fold piece by flip the polygon shape, and adjust the bounding box accordingly.
-        fold_line: "top" (higher y-coord) or "bottom" (lower y-coord)
+        fold_line: "top" (higher y-coord), "bottom" (lower y-coord), "left" (low x-coord), or "right" (high x-coord)
         """
 
-        if fold_line != "top" and fold_line != "bottom":
+        if (
+            fold_line != "top"
+            and fold_line != "bottom"
+            and fold_line != "left"
+            and fold_line != "right"
+        ):
             print("Wrong input for fold_line!")
             return
 
-        num_orig_contour_points = len(self.contour)
+        # find the fold line axis
+        if fold_line == "bottom":
+            fold_line_axis = self.y + self.height
+        elif fold_line == "top":
+            fold_line_axis = self.y
+        elif fold_line == "left":
+            fold_line_axis = self.x
+        elif fold_line == "right":
+            fold_line_axis = self.x + self.width
 
-        # TODO: find the first point that the fold line starts, reorder points
+        is_hori = fold_line == "top" or fold_line == "bottom"
 
-        for i in reversed(range(num_orig_contour_points)):
+        # print(
+        #    "Trying to manipulate shape with fold_line on the {}, fold_line_axis={}:".format(
+        #        fold_line, fold_line_axis
+        #    )
+        # )
+
+        # find the indices of the points that are on the fold line
+        fold_line_indices = []
+        started = False
+        segment_indices = [-1, -1]
+        for i in range(len(self.contour)):
             coord = self.contour[i]
-            if fold_line == "top":
-                fold_line_axis = self.y + self.height
+            prev_coord = self.contour[i - 1]
+
+            if test_same_line(prev_coord, coord, is_hori, fold_line_axis):
+                if not started:
+                    started = True
+                    segment_indices[0] = i
+
+                segment_indices[1] = i + 1
+            else:
+                if started:
+                    started = False
+                    fold_line_indices.append(segment_indices)
+                    segment_indices = [-1, -1]
+
+        # print(fold_line_indices)
+
+        # skip the points on the fold line and rearrange contour points so
+        # the first point is the point right after the last fold line point
+        last_index = fold_line_indices[-1][1]
+        new_contour = self.contour[last_index:]
+        for i in range(len(fold_line_indices)):
+            indices = fold_line_indices[i]
+            if i == 0:
+                new_contour.extend(self.contour[0 : indices[0]])
+            else:
+                prev = fold_line_indices[i - 1]
+                new_contour.extend(self.contour[prev[1] + 1 : indices[0]])
+
+        # update contour
+        self.contour = new_contour
+        # print(self.contour)
+
+        # add the new mirrorred points
+        for i in reversed(range(len(self.contour))):
+            coord = self.contour[i]
+            if fold_line == "bottom":
                 new_y_coord = fold_line_axis - coord[1] + fold_line_axis
                 self.contour.append([coord[0], new_y_coord])
 
-            elif fold_line == "bottom":
-                fold_line_axis = self.y
+            elif fold_line == "top":
                 new_y_coord = fold_line_axis - (coord[1] - fold_line_axis)
                 self.contour.append([coord[0], new_y_coord])
 
-        self.height = self.height * 2
-        self.bbox_h += self.height
+            elif fold_line == "left":
+                new_x_coord = fold_line_axis - (coord[0] - fold_line_axis)
+                self.contour.append([new_x_coord, coord[1]])
 
-        if fold_line == "bottom":
+            else:
+                new_x_coord = fold_line_axis - coord[0] + fold_line_axis
+                self.contour.append([new_x_coord, coord[1]])
+
+        # update shape and bounding box traits
+        if fold_line == "top":
             self.y -= self.height
             self.bbox_low_y -= self.height
+        elif fold_line == "left":
+            self.x -= self.width
+            self.bbox_low_x -= self.width
+
+        if is_hori:
+            self.bbox_h += self.height
+            self.height = self.height * 2
+        else:
+            self.bbox_w += self.width
+            self.width = self.width * 2
+
+    def findCorners(self):
+        """
+        Finding corners of the shape. Ignore for now, but might be useful later on?
+        """
+        SPACE = 20
+        max_x = (int)(self.x + self.width + SPACE)
+        max_y = (int)(self.y + self.height + SPACE)
+
+        mask = np.zeros((max_y, max_x), dtype="uint8")
+        points = np.array(self.contour)
+        cv.fillPoly(mask, np.int32([points]), (255, 255, 255))
+
+        dst = cv.cornerHarris(mask, 5, 3, 0.04)
+        ret, dst = cv.threshold(dst, 0.1 * dst.max(), 255, 0)
+        dst = np.uint8(dst)
+        ret, labels, stats, centroids = cv.connectedComponentsWithStats(dst)
+        criteria = (cv.TERM_CRITERIA_EPS + cv.TERM_CRITERIA_MAX_ITER, 100, 0.001)
+        corners = cv.cornerSubPix(
+            mask, np.float32(centroids), (5, 5), (-1, -1), criteria
+        )
+
+        # convert to integer
+        centroids = np.int0(centroids)
+        corners = np.int0(corners)
+
+        # print(corners)
+        # print(centroids)
+
+        return corners

--- a/api/polygon.py
+++ b/api/polygon.py
@@ -93,3 +93,36 @@ class Polygon(object):
                 coord[1] = centre_y - (coord[1] - centre_y)
             else:
                 coord[1] = centre_y + (centre_y - coord[1])
+
+    def centre_fold_manip(self, fold_line):
+        """
+        Manipulate the centre fold piece by flip the polygon shape, and adjust the bounding box accordingly.
+        fold_line: "top" (higher y-coord) or "bottom" (lower y-coord)
+        """
+
+        if fold_line != "top" and fold_line != "bottom":
+            print("Wrong input for fold_line!")
+            return
+
+        num_orig_contour_points = len(self.contour)
+
+        # TODO: find the first point that the fold line starts, reorder points
+
+        for i in reversed(range(num_orig_contour_points)):
+            coord = self.contour[i]
+            if fold_line == "top":
+                fold_line_axis = self.y + self.height
+                new_y_coord = fold_line_axis - coord[1] + fold_line_axis
+                self.contour.append([coord[0], new_y_coord])
+
+            elif fold_line == "bottom":
+                fold_line_axis = self.y
+                new_y_coord = fold_line_axis - (coord[1] - fold_line_axis)
+                self.contour.append([coord[0], new_y_coord])
+
+        self.height = self.height * 2
+        self.bbox_h += self.height
+
+        if fold_line == "bottom":
+            self.y -= self.height
+            self.bbox_low_y -= self.height


### PR DESCRIPTION
## Description

Adding backend support to handle shapes that have a cut-on-centre-fold instruction. For shapes with centre-fold, they will be mirrored and represented as a full shape in our database before they undergo packing and nesting.  

Fixes #43

## How it was implemented

Step 1: After determining the fold line axis, the function will obtain all points that are on this centre fold line. To account for small pixel changes in a supposedly straight line, a dx by dy heuristic is used to determine if a point is part of the line. That is, for a horizontal line for example, if dy/dx is tiny between the two points, we assume they are on the same line. 

Step 2: After getting the indices of the fold line coordinates, remove these points and rearrange all the contour points so that the first point in the contour coordinates list is the point right after the last centre fold line point. This is done so that when mirrored points are added to this list, we can still construct a correct closed shape contour.  

Step 3: calculate the mirror point of all coordinates in the contour list and add them to the contour. 


## How it was tested

Tested locally with a cut-on-centre-fold shape. All four sides: top, bottom, left, right, work. 

## Screenshots or video
Original shape: 
<img width="917" alt="image" src="https://github.com/Joshua-Pow/Placement/assets/61958332/de9a4a40-ec73-409e-9045-c71d4204edd8">

Fold on top:
![image](https://github.com/Joshua-Pow/Placement/assets/61958332/79d4b43a-561e-4ea6-b580-6a11d03eee86)

Fold on left (won't happen in real life but to show it works):
![image](https://github.com/Joshua-Pow/Placement/assets/61958332/b86e95a4-1a7b-404c-b2fc-30080a64ae78)

