### PR TITLE
Issue74/Fixed the way duplicate pieces have their IDs generated

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -135,7 +135,7 @@ class Pdf(Resource):
             json_polygons[polygon.pid] = polygon.toJSON()
 
         with open(f"api/polygons/{next_id}.json", "w") as file:
-            json.dump(json_polygons, file)
+            json.dump(json_polygons, file, indent=4)
 
         return {"id": next_id}
 
@@ -174,7 +174,7 @@ class Poll(Resource):
 
         with open(f"api/polygons/{id}.json", "r") as file:
             polygons = json.load(file)
-            #print(json.dumps(polygons, indent=4))
+            # print(json.dumps(polygons, indent=4))
 
         # Convert json to list of Polygon objects
         polygonArray = []

--- a/api/parse_svg_input_constaints.py
+++ b/api/parse_svg_input_constaints.py
@@ -106,7 +106,11 @@ def duplicate_polygon(
         print("invalid pid for piece duplication!")
         return
 
-    p = next((poly for poly in polygons if poly.pid == pid), None)
+    p = None
+    for poly in polygons:
+        if poly.pid == pid:
+            p = poly
+            break
     if p is None:
         print("invalid pid for piece duplication!")
         return

--- a/api/parse_svg_input_constaints.py
+++ b/api/parse_svg_input_constaints.py
@@ -94,7 +94,7 @@ def translate_polygons_to_SVG(polygons, viewbox_width, viewbox_height, new_filen
 
 
 def duplicate_polygon(
-    polygons: list[Polygon], pid: int, quantity: int, len_polygons: int
+    polygons: list[Polygon], pid: int, quantity: int, amount_shapes: int
 ):
     """
     Duplicate a particular polygon shape in the polygond data structure to a certain quantity.
@@ -106,10 +106,17 @@ def duplicate_polygon(
         print("invalid pid for piece duplication!")
         return
 
-    p = polygons[pid]
+    p = next((poly for poly in polygons if poly.pid == pid), None)
+    if p is None:
+        print("invalid pid for piece duplication!")
+        return
     mirror = quantity % 2 == 0  # even quantity
 
     for i in range(quantity - 1):
+        new_pid = max(
+            amount_shapes,
+            max([p.pid for p in polygons if p.pid is not None]) + 1,
+        )
         new = Polygon(
             copy.deepcopy(p.getContour()),
             p.x,
@@ -117,9 +124,9 @@ def duplicate_polygon(
             p.width,
             p.height,
             bonding_box_margin=p.bonding_box_margin,
-            pid=len_polygons + i,
+            pid=new_pid,
         )
-
+        print("new pid", new_pid)
         if mirror and (i % 2 == 0):
             new.mirror_around_centre_x_axis()
         polygons.append(new)

--- a/api/polygon.py
+++ b/api/polygon.py
@@ -120,15 +120,15 @@ class Polygon(object):
         self.y += y_move
         # bbox_list[i] = [ [x1,y1], [x2,y2] ]
         if self.bbox_list != []:
-            for i in range (len(self.bbox_list)):
-                print(f"minx = {self.bbox_list[i][0][0]} and type of min is {type(self.bbox_list[i][0])}" )
-                self.bbox_list[i][0][0] += x_move 
+            for i in range(len(self.bbox_list)):
+                # print(f"minx = {self.bbox_list[i][0][0]} and type of min is {type(self.bbox_list[i][0])}" )
+                self.bbox_list[i][0][0] += x_move
                 self.bbox_list[i][1][0] += x_move
                 self.bbox_list[i][0][1] += y_move
                 self.bbox_list[i][1][1] += y_move
             #     print(f"{self.bbox_list[i][0][0]+x_move},{self.bbox_list[i][0][1]+y_move}")
             #     tup_min = (self.bbox_list[i][0][0]+x_move, self.bbox_list[i][0][1]+y_move)
-            #     tup_max = (self.bbox_list[i][1][0]+x_move, self.bbox_list[i][1][1]+y_move)
+            #     tup_max = (self.bbox_list[i][1][0]+x_move,S self.bbox_list[i][1][1]+y_move)
             #     new_tup = (tup_min, tup_max)
             #     new_list.append(new_tup)
             # self.bbox_list = new_list


### PR DESCRIPTION
## Description

The ID number for duplicates used to be the original shape count +1, but when you had multiple duplicates they would overwrite each others IDs.

Fixes #74

## How it was implemented

When creating an ID for duplicate pieces we take the max between the number of original shapes and the IDs already generated (in case other duplicates have already been created and their IDs are incremented +1 from the amount of original shapes)

## How it was tested

Manually checking JSON data and /poll generated SVGs

## Screenshots or video

multiple rectangles and shirt pieces:
<img width="680" alt="image" src="https://github.com/Joshua-Pow/Placement/assets/51868988/3357da7e-ffcc-4f5e-8f19-b391a8d9b572">

